### PR TITLE
Fix PTY terminal and restore routes with auto-cleanup

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -13,7 +13,6 @@ require_relative 'core/ui_helpers'
 require_relative 'core/ifaces'
 require_relative 'core/profiles'
 require_relative 'core/tasks'
-require_relative 'routes/tty'
 
 
 # Autoload modules
@@ -268,60 +267,8 @@ class HackberryApp < Sinatra::Base
     redirect "/tasks?session=#{res[:session]}"
   end
 
-  # ==== PTY Terminal (tmux-free, reliable) ====
-require_relative 'core/tty'
-
-get '/tty' do
-  @sessions = Hackberry::TTY.list
-  erb :tty
-end
-
-post '/tty/new' do
-  id = Hackberry::TTY.create(log_dir: CONFIG['paths']['logs'])
-  redirect "/tty/#{id}"
-end
-
-get '/tty/:id' do
-  @session = params[:id]
-  halt 404, "No such terminal" unless Hackberry::TTY.list.include?(@session)
-  erb :tty
-end
-
-# Poll the last ~2000 bytes of output
-get '/tty/:id/snap' do
-  content_type 'text/plain'
-  id = params[:id]
-  halt 404 unless Hackberry::TTY.list.include?(id)
-  out = Hackberry::TTY.snapshot(id, bytes: 4000)
-  out.empty? ? "[no output yet]" : out
-end
-
-# Send text / keys
-post '/tty/:id/send' do
-  id = params[:id]
-  halt 404 unless Hackberry::TTY.list.include?(id)
-  if params['text'] && !params['text'].empty?
-    Hackberry::TTY.write(id, params['text'])
-    Hackberry::TTY.send_key(id, :enter)
-  else
-    case params['key']
-    when 'ENTER'  then Hackberry::TTY.send_key(id, :enter)
-    when 'CTRL_C' then Hackberry::TTY.send_key(id, :ctrl_c)
-    when 'TAB'    then Hackberry::TTY.send_key(id, :tab)
-    end
-  end
-  status 204
-end
-
-post '/tty/:id/stop' do
-  id = params[:id]
-  Hackberry::TTY.stop(id)
-  redirect '/tty'
-end
-# ==== end PTY Terminal ====
-
-# ===== DEBUG: list mounted routes =====
-get '/_routes' do
+  # ===== DEBUG: list mounted routes =====
+  get '/_routes' do
   content_type 'text/plain'
   out = +""
   self.class.routes.each do |verb, arr|
@@ -364,5 +311,7 @@ end
     end
   end
 end
+
+require_relative 'routes/tty'
 
 HackberryApp.run! if $0 == __FILE__

--- a/views/tty.erb
+++ b/views/tty.erb
@@ -25,7 +25,7 @@
     <button type="submit" class="pill">New Shell</button>
   </form>
 
-  <h3>Existing tmux sessions</h3>
+    <h3>Existing terminal sessions</h3>
   <ul class="sessions">
     <% @sessions.each do |s| %>
       <li>


### PR DESCRIPTION
## Summary
- auto-remove PTY sessions from registry when shell exits
- move PTY terminal endpoints into a dedicated routes file and require it
- refresh terminal view text to drop tmux wording

## Testing
- `bundle exec ruby -c app.rb`
- `bundle exec ruby -c routes/tty.rb`
- `bundle exec ruby -c core/tty.rb`
- `bundle exec erb -x -T - views/tty.erb | ruby -c` *(fails: Could not find gem 'sinatra')*

------
https://chatgpt.com/codex/tasks/task_e_68a5809d491883319df381954535bafc